### PR TITLE
Add a scroll deadzone for the mouse mode

### DIFF
--- a/config-example.ini
+++ b/config-example.ini
@@ -29,6 +29,11 @@ save_mac_address = 0
 # 0 = Disabled, 1 = Automatic (Switch between mouse and controller mode), 2 = Always (Mouse only (Not working on both Joy-Cons because is useless))
 mouse_mode = 0
 
+# Scroll deadzone for calibration
+# Deadzone for scroll wheel movement to avoid unintentional scrolling
+# Ranges from -32767 to 32767, though seems to peak at around 28452 positive
+scroll_deadzone = 5500
+
 [Bluetooth]
 # Mac address of your computer
 # This is used to connect automatically to the Joy-Con without pressing the sync button

--- a/config.py
+++ b/config.py
@@ -10,6 +10,7 @@ class Config:
         "save_mac_address": False,
         "enable_dsu": False,
         "mouse_mode": 0,
+        "scroll_deadzone": 0,
         "mac_address": "FFFFFFFFFFFF"
     }
 
@@ -40,6 +41,7 @@ class Config:
             self.save_mac_address = section.get("save_mac_address", str(self.save_mac_address)).lower() == '1'
             self.enable_dsu = section.get("enable_dsu", str(self.enable_dsu)).lower() == '1'
             self.mouse_mode = int(section.get("mouse_mode", self.mouse_mode if self.mouse_mode == 0 or self.mouse_mode == 1 or self.mouse_mode == 2 else 0))
+            self.scroll_deadzone = int(section.get("scroll_deadzone", self.scroll_deadzone))
         
             if "Bluetooth" in config_parser:
                 section = config_parser["Bluetooth"]
@@ -64,5 +66,6 @@ class Config:
             "save_mac_address": self.save_mac_address,
             "enable_dsu": self.enable_dsu,
             "mouse_mode": self.mouse_mode,
+            "scroll_deadzone": self.scroll_deadzone,
             "mac_address": self.mac_address
         }

--- a/controllers/JoyconL.py
+++ b/controllers/JoyconL.py
@@ -105,6 +105,9 @@ class JoyConLeft:
 
         self.analog_stick["X"], self.analog_stick["Y"] = joystick_decoder(JoystickDatas, self.orientation)
 
+        if self.mouseBtn["scrollY"] < self.config["scroll_deadzone"] and self.mouseBtn["scrollY"] > self.config["scroll_deadzone"] * -1:
+            self.mouseBtn["scrollY"] = 0
+
         self.mouseBtn["Left"] = bool(btnDatas & 0x0040) #L
         self.mouseBtn["Right"] = bool(btnDatas & 0x0080) #ZL
         self.mouseBtn["scrollX"], self.mouseBtn["scrollY"] = scroll_decoder(JoystickDatas)

--- a/controllers/JoyconR.py
+++ b/controllers/JoyconR.py
@@ -4,6 +4,8 @@ import os
 import ctypes
 import struct
 
+from config import Config
+
 class JoyConRight:
     def __init__(self):
         self.name = "Joy-Con"
@@ -66,6 +68,10 @@ class JoyConRight:
         self.alertSent = False
         self.is_connected = False
 
+        
+        # Read the configuration from config.ini
+        self.config = Config().getConfig()
+
     async def update(self, datas):
         # Update button states based on the received data
         btnDatas = datas[4] << 8 | datas[5]
@@ -119,7 +125,9 @@ class JoyConRight:
         self.mouseBtn["Right"] = bool(btnDatas & 0x8000) #ZR
         self.mouseBtn["scrollX"], self.mouseBtn["scrollY"] = scroll_decoder(JoystickDatas)
 
-        #print(f"{self.mouseBtn['scrollX']}, {self.mouseBtn['scrollY']}")
+        if self.mouseBtn["scrollY"] < self.config["scroll_deadzone"] and self.mouseBtn["scrollY"] > self.config["scroll_deadzone"] * -1:
+            self.mouseBtn["scrollY"] = 0
+        # print(f"{self.mouseBtn['scrollX']}, {self.mouseBtn['scrollY']}")
 
         # Update battery level only if the new value is lower than the current one
         battery_raw = (datas[31]) | (datas[32] << 8)


### PR DESCRIPTION
Adds a field to the config-example.ini which allows the user to define a scroll deadzone (by default 5500).
If the current scroll strength is within this range, it is set to 0.